### PR TITLE
feat(assessment): add AI-powered CEFR evaluation (OpenAI GPT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ speak-check/
 ├── tts.py              # Text-to-Speech functionality (Microsoft Edge TTS)
 ├── recording.py        # Voice recording functionality (PyAudio)
 ├── stt_openai.py       # Speech-to-text functionality (OpenAI Whisper API)
-├── evaluate.py         # AI-based CEFR scoring and evaluation
+├── eval_openai.py      # AI-based CEFR assessment (OpenAI GPT)
 ├── evaluate.py         # AI-based CEFR scoring and evaluation
 ├── test_recording.py   # Voice recording test script
 ├── requirements.txt    # Python dependencies
@@ -115,6 +115,14 @@ Handles speech-to-text conversion using OpenAI Whisper API:
 - Cloud-based processing for scalability
 - Automatic error handling and retry logic
 
+#### `eval_openai.py`
+Provides AI-powered CEFR assessment (OpenAI GPT):
+- Multi-criteria assessment (fluency, accuracy, lexical range, etc.)
+- CEFR level prediction based on linguistic analysis
+- Detailed feedback generation
+- Personalized improvement recommendations
+- Benchmark comparison against CEFR standards
+
 #### `evaluate.py`
 Provides AI-powered CEFR evaluation:
  - Multi-criteria assessment (fluency, accuracy, lexical range, etc.)
@@ -122,14 +130,6 @@ Provides AI-powered CEFR evaluation:
  - Detailed feedback generation
  - Personalized improvement recommendations
  - Benchmark comparison against CEFR standards
-
-#### `evaluate.py`
-Provides AI-powered CEFR evaluation:
-- Multi-criteria assessment (fluency, accuracy, lexical range, etc.)
-- CEFR level prediction based on linguistic analysis
-- Detailed feedback generation
-- Personalized improvement recommendations
-- Benchmark comparison against CEFR standards
 
 ## 🛠️ Current Status
 
@@ -148,6 +148,7 @@ Provides AI-powered CEFR evaluation:
 - ✅ **Audio Quality Controls** (speed, volume, voice selection)
 - ✅ **Thread-safe Operations** with robust error handling
 - ✅ **Modular Architecture** with clean separation of concerns
+- ✅ **AI Assessment** using OpenAI GPT for detailed feedback
 
 ### 🔄 TODO: Advanced Features to Implement
 - 🔄 **AI evaluation** using language models (OpenAI/Claude)
@@ -252,3 +253,37 @@ The app now supports managed speech transcription using OpenAI's Whisper API:
 - OpenAI Whisper API charges per minute of audio processed
 - Current pricing: ~$0.006 per minute (very affordable for practice)
 - No charges for failed transcriptions or API errors
+
+## 🤖 AI Assessment (OpenAI GPT)
+
+The app now provides AI-powered CEFR level assessment using OpenAI's GPT models:
+
+### Setup Requirements
+- **OpenAI API Key**: Same key used for STT (set `OPENAI_API_KEY` in `.env`)
+- **Internet Connection**: Required for API calls to OpenAI
+- **Transcript**: Requires a transcribed speech response
+
+### How to Use
+1. Enable "AI Assessment" in the sidebar settings
+2. Complete a recording and transcription (see STT section above)
+3. Click "Evaluate Response" to get detailed AI feedback
+4. Review your CEFR level, scores, and personalized recommendations
+
+### Assessment Criteria
+- **Fluency**: Natural flow, hesitations, speech rate
+- **Accuracy**: Grammatical correctness, vocabulary precision
+- **Grammar**: Sentence structure complexity, error patterns
+- **Vocabulary**: Word choice, lexical range, sophistication
+- **Coherence**: Logical organization, topic relevance, completeness
+
+### Features
+- **CEFR Level Prediction**: AI-determined proficiency level (A2-C1)
+- **Detailed Scoring**: 0-10 scale for each assessment criterion
+- **Personalized Feedback**: Strengths, areas for improvement, and actionable tips
+- **Confidence Scoring**: Assessment reliability indicator
+- **Fallback Mode**: Basic assessment when API is unavailable
+
+### Cost Considerations
+- OpenAI GPT API charges per token processed
+- Current pricing: ~$0.0001 per 1K tokens (very affordable)
+- Typical assessment: 500-1000 tokens per evaluation

--- a/eval_openai.py
+++ b/eval_openai.py
@@ -1,0 +1,212 @@
+"""
+OpenAI-based CEFR Assessment Module
+
+This module provides AI-powered evaluation of speaking responses using OpenAI's GPT models
+to assess CEFR levels and provide detailed feedback.
+"""
+
+import os
+import json
+import logging
+from typing import Dict, Any, Optional, List
+from dataclasses import dataclass
+from dotenv import load_dotenv
+
+# Load environment variables from .env if present
+load_dotenv()
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+@dataclass
+class CEFRAssessment:
+    """Structured CEFR assessment result."""
+    overall_level: str  # A2, B1, B2, C1
+    confidence: float  # 0.0-1.0
+    scores: Dict[str, float]  # fluency, accuracy, grammar, vocabulary, coherence
+    word_count: int
+    rationale: str
+    actionable_tips: List[str]
+    strengths: List[str]
+    areas_for_improvement: List[str]
+
+def _ensure_openai_available() -> bool:
+    """Check if OpenAI client is available and API key is set."""
+    try:
+        from openai import OpenAI  # noqa: F401
+        api_key = os.getenv('OPENAI_API_KEY')
+        if not api_key:
+            logger.error("OPENAI_API_KEY environment variable not set")
+            return False
+        return True
+    except Exception:
+        logger.error("OpenAI client not installed. Run: pip install openai")
+        return False
+
+def _create_assessment_prompt(transcript: str, target_level: str, question: str) -> str:
+    """Create a structured prompt for CEFR assessment."""
+    
+    # Truncate very long transcripts to avoid token limits
+    max_words = 300
+    words = transcript.split()
+    if len(words) > max_words:
+        transcript = " ".join(words[:max_words]) + " [truncated]"
+    
+    prompt = f"""You are an expert CEFR (Common European Framework of Reference) assessor. 
+Evaluate the following English speaking response and provide a structured assessment.
+
+QUESTION: {question}
+TARGET LEVEL: {target_level}
+RESPONSE: "{transcript}"
+
+Provide your assessment in the following JSON format:
+{{
+    "overall_level": "A2|B1|B2|C1",
+    "confidence": 0.0-1.0,
+    "scores": {{
+        "fluency": 0.0-10.0,
+        "accuracy": 0.0-10.0, 
+        "grammar": 0.0-10.0,
+        "vocabulary": 0.0-10.0,
+        "coherence": 0.0-10.0
+    }},
+    "word_count": <integer>,
+    "rationale": "<detailed explanation of the assessment>",
+    "actionable_tips": ["<specific tip 1>", "<specific tip 2>", ...],
+    "strengths": ["<strength 1>", "<strength 2>", ...],
+    "areas_for_improvement": ["<area 1>", "<area 2>", ...]
+}}
+
+Assessment criteria:
+- Fluency: Natural flow, hesitations, speech rate
+- Accuracy: Grammatical correctness, vocabulary precision  
+- Grammar: Sentence structure complexity, error patterns
+- Vocabulary: Word choice, lexical range, sophistication
+- Coherence: Logical organization, topic relevance, completeness
+
+CEFR level guidelines:
+- A2: Basic phrases, simple sentences, familiar topics (50+ words)
+- B1: Connected speech, personal experiences, some complexity (100+ words)  
+- B2: Spontaneous interaction, abstract topics, detailed explanations (150+ words)
+- C1: Flexible language use, complex arguments, subtle meanings (200+ words)
+
+Respond only with valid JSON."""
+
+    return prompt
+
+def assess_speaking_response(
+    transcript: str,
+    target_level: str = "B1", 
+    question: str = "",
+    model: str = "gpt-4o-mini"
+) -> CEFRAssessment:
+    """
+    Assess a speaking response using OpenAI GPT for CEFR evaluation.
+    
+    Args:
+        transcript: The transcribed speech text
+        target_level: Target CEFR level (A2, B1, B2, C1)
+        question: The original speaking prompt/question
+        model: OpenAI model to use for assessment
+        
+    Returns:
+        CEFRAssessment: Structured assessment results
+    """
+    if not _ensure_openai_available():
+        return _fallback_assessment(transcript, target_level)
+    
+    if not transcript or not transcript.strip():
+        return _fallback_assessment("", target_level)
+    
+    try:
+        from openai import OpenAI
+        
+        client = OpenAI()
+        prompt = _create_assessment_prompt(transcript, target_level, question)
+        
+        logger.info(f"Assessing transcript with OpenAI {model}")
+        
+        response = client.chat.completions.create(
+            model=model,
+            messages=[
+                {
+                    "role": "system", 
+                    "content": "You are an expert CEFR assessor. Provide assessments in valid JSON format only."
+                },
+                {
+                    "role": "user",
+                    "content": prompt
+                }
+            ],
+            response_format={"type": "json_object"},
+            temperature=0.1,  # Low temperature for consistent assessments
+            max_tokens=1000
+        )
+        
+        # Parse the JSON response
+        try:
+            result_data = json.loads(response.choices[0].message.content)
+            
+            return CEFRAssessment(
+                overall_level=result_data.get("overall_level", "B1"),
+                confidence=float(result_data.get("confidence", 0.7)),
+                scores=result_data.get("scores", {
+                    "fluency": 6.0, "accuracy": 6.0, "grammar": 6.0, 
+                    "vocabulary": 6.0, "coherence": 6.0
+                }),
+                word_count=int(result_data.get("word_count", len(transcript.split()))),
+                rationale=result_data.get("rationale", "Assessment completed"),
+                actionable_tips=result_data.get("actionable_tips", []),
+                strengths=result_data.get("strengths", []),
+                areas_for_improvement=result_data.get("areas_for_improvement", [])
+            )
+            
+        except (json.JSONDecodeError, KeyError, ValueError) as e:
+            logger.error(f"Failed to parse OpenAI response: {e}")
+            return _fallback_assessment(transcript, target_level)
+            
+    except Exception as e:
+        logger.error(f"OpenAI assessment error: {e}")
+        return _fallback_assessment(transcript, target_level)
+
+def _fallback_assessment(transcript: str, target_level: str) -> CEFRAssessment:
+    """Provide a basic fallback assessment when OpenAI is unavailable."""
+    
+    word_count = len(transcript.split()) if transcript else 0
+    
+    # Simple heuristics for fallback
+    if word_count < 30:
+        level = "A2"
+        scores = {"fluency": 4.0, "accuracy": 4.0, "grammar": 4.0, "vocabulary": 4.0, "coherence": 4.0}
+    elif word_count < 80:
+        level = "B1" 
+        scores = {"fluency": 6.0, "accuracy": 6.0, "grammar": 6.0, "vocabulary": 6.0, "coherence": 6.0}
+    elif word_count < 150:
+        level = "B2"
+        scores = {"fluency": 7.0, "accuracy": 7.0, "grammar": 7.0, "vocabulary": 7.0, "coherence": 7.0}
+    else:
+        level = "C1"
+        scores = {"fluency": 8.0, "accuracy": 8.0, "grammar": 8.0, "vocabulary": 8.0, "coherence": 8.0}
+    
+    return CEFRAssessment(
+        overall_level=level,
+        confidence=0.5,
+        scores=scores,
+        word_count=word_count,
+        rationale="Basic assessment using word count and simple heuristics",
+        actionable_tips=["Practice speaking more to improve fluency", "Expand vocabulary"],
+        strengths=["Good effort in responding"],
+        areas_for_improvement=["Consider using more complex structures", "Work on accuracy"]
+    )
+
+def is_available() -> bool:
+    """Check if OpenAI assessment is available."""
+    return _ensure_openai_available()
+
+def get_assessment_providers() -> List[str]:
+    """Get available assessment providers."""
+    providers = ["baseline"]
+    if is_available():
+        providers.append("openai")
+    return providers


### PR DESCRIPTION
This PR adds AI-powered CEFR assessment for speaking responses.\n\nKey changes:\n- New val_openai.py: OpenAI GPT-based assessment returning structured JSON (level, scores, rationale, tips) with fallback heuristics\n- valuate.py: integrates provider to produce EvaluationResult; logs and graceful fallback\n- pp.py: sidebar toggle for AI Assessment, Evaluate button, results UI (metrics, feedback, recommendations)\n- README.md: docs for setup, usage, criteria, and cost considerations\n\nConfig:\n- Reuses OPENAI_API_KEY from .env via python-dotenv\n\nTesting:\n- Local run: record → transcribe → enable AI Assessment → Evaluate; results render with metrics and feedback\n\nFollow-ups:\n- Optionally add streaming mic (browser) and alternative providers (Azure/Google) behind the same interface.