### PR TITLE
feat(mongo): persist sessions/history in MongoDB and add History UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
-# Environment variables for speak-check
+# Environment variables
 OPENAI_API_KEY=
+MONGODB_URI=mongodb://localhost:27017
+MONGODB_DB=speak_check

--- a/db_mongo/client.py
+++ b/db_mongo/client.py
@@ -1,0 +1,9 @@
+import os
+from pymongo import MongoClient
+from dotenv import load_dotenv
+
+load_dotenv()
+MONGODB_URI = os.getenv("MONGODB_URI", "mongodb://localhost:27017")
+MONGODB_DB = os.getenv("MONGODB_DB", "speak_check")
+client = MongoClient(MONGODB_URI)
+db = client[MONGODB_DB]

--- a/db_mongo/crud.py
+++ b/db_mongo/crud.py
@@ -1,0 +1,108 @@
+from datetime import datetime
+from bson import ObjectId
+from .client import db
+
+# Sessions
+
+def create_session(level: str, user_id: str | None = None) -> str:
+    doc = {
+        "user_id": ObjectId(user_id) if user_id else None,
+        "level": level,
+        "status": "active",
+        "started_at": datetime.utcnow(),
+        "ended_at": None,
+        "metadata": None,
+    }
+    res = db.sessions.insert_one(doc)
+    return str(res.inserted_id)
+
+
+def end_session(session_id: str, status: str = "completed") -> None:
+    db.sessions.update_one(
+        {"_id": ObjectId(session_id)},
+        {"$set": {"status": status, "ended_at": datetime.utcnow()}},
+    )
+
+
+# Recordings
+
+def add_recording(
+    session_id: str,
+    file_url: str,
+    duration_s: float | None = None,
+    sample_rate: int | None = None,
+    channels: int = 1,
+) -> str:
+    res = db.recordings.insert_one(
+        {
+            "session_id": ObjectId(session_id),
+            "file_url": file_url,
+            "duration_s": duration_s,
+            "sample_rate": sample_rate,
+            "channels": channels,
+            "created_at": datetime.utcnow(),
+        }
+    )
+    return str(res.inserted_id)
+
+
+# Transcripts
+
+def add_transcript(
+    recording_id: str,
+    text: str,
+    language: str,
+    provider: str,
+    model: str,
+    segments: list | None = None,
+) -> str:
+    res = db.transcripts.insert_one(
+        {
+            "recording_id": ObjectId(recording_id),
+            "text": text,
+            "language": language,
+            "provider": provider,
+            "model": model,
+            "segments": segments or [],
+            "created_at": datetime.utcnow(),
+        }
+    )
+    return str(res.inserted_id)
+
+
+# Evaluations
+
+def add_evaluation(
+    transcript_id: str,
+    overall_level: str,
+    confidence: float,
+    scores: dict,
+    rationale: str,
+    tips: list[str] | None = None,
+) -> str:
+    res = db.evaluations.insert_one(
+        {
+            "transcript_id": ObjectId(transcript_id),
+            "overall_level": overall_level,
+            "confidence": confidence,
+            "scores": scores,
+            "rationale": rationale,
+            "tips": tips or [],
+            "created_at": datetime.utcnow(),
+        }
+    )
+    return str(res.inserted_id)
+
+
+# Queries
+
+def list_sessions(user_id: str | None = None, limit: int = 20) -> list[dict]:
+    q = {"user_id": ObjectId(user_id)} if user_id else {}
+    return list(db.sessions.find(q).sort("started_at", -1).limit(limit))
+
+
+def get_session_detail(session_id: str) -> dict:
+    sid = ObjectId(session_id)
+    s = db.sessions.find_one({"_id": sid})
+    recs = list(db.recordings.find({"session_id": sid}).sort("created_at", -1))
+    return {"session": s, "recordings": recs}

--- a/docs/datastructure.md
+++ b/docs/datastructure.md
@@ -1,0 +1,116 @@
+# Data Structure and Persistence Design (MongoDB)
+
+## Goals
+- Persist speaking test sessions with level, timestamps, and status.
+- Enable resuming in-progress sessions and reviewing past sessions (recordings, transcripts, evaluations).
+- Keep the app portable for dev (local MongoDB) and cloud (managed Mongo).
+
+## MongoDB Setup
+- URI: `MONGODB_URI` (default: `mongodb://localhost:27017`)
+- DB: `MONGODB_DB` (default: `speak_check`)
+- Client: `pymongo`
+
+## Collections
+
+### users (optional)
+```
+{
+  _id: ObjectId,
+  email: string?,
+  name: string?,
+  created_at: Date
+}
+```
+
+### sessions
+```
+{
+  _id: ObjectId,
+  user_id: ObjectId | null,
+  level: 'A2'|'B1'|'B2'|'C1',
+  status: 'active'|'completed'|'abandoned',
+  started_at: Date,
+  ended_at: Date | null,
+  metadata: object | null
+}
+```
+Indexes:
+- { user_id: 1, started_at: -1 }
+- { status: 1 }
+
+### recordings
+```
+{
+  _id: ObjectId,
+  session_id: ObjectId,
+  file_url: string,           // path or S3 URL
+  duration_s: number?,
+  sample_rate: number?,
+  channels: number,           // default 1
+  created_at: Date
+}
+```
+Indexes:
+- { session_id: 1, created_at: -1 }
+
+### transcripts
+```
+{
+  _id: ObjectId,
+  recording_id: ObjectId,
+  text: string,
+  language: string,
+  provider: string,           // 'openai'
+  model: string,              // 'whisper-1'
+  segments: array?,
+  created_at: Date
+}
+```
+Indexes:
+- { recording_id: 1 }
+
+### evaluations
+```
+{
+  _id: ObjectId,
+  transcript_id: ObjectId,
+  overall_level: 'A2'|'B1'|'B2'|'C1',
+  confidence: number,         // 0..1
+  scores: object,             // {fluency, accuracy, grammar, vocabulary, coherence}
+  rationale: string,
+  tips: array,
+  created_at: Date
+}
+```
+Indexes:
+- { transcript_id: 1 }
+
+### events (audit/analytics)
+```
+{
+  _id: ObjectId,
+  session_id: ObjectId,
+  type: string,               // 'start'|'record_stop'|'transcribe'|'evaluate'
+  payload: object?,
+  created_at: Date
+}
+```
+Indexes:
+- { session_id: 1, created_at: 1 }
+
+## UI Integration Flow
+- Start Speaking Test → insert `sessions`; store `_id` in `st.session_state.test_session_id`.
+- Stop Recording → insert `recordings` with file path and duration.
+- Transcribe → insert `transcripts` with text and metadata.
+- Evaluate → insert `evaluations` with scores and rationale.
+- History sidebar → `list_sessions()` → select → resume by setting `test_session_id`, `current_level`, `test_started=True`.
+
+## Decisions
+- Audio blobs stay on disk/S3; DB stores metadata. GridFS optional if you must store blobs.
+- Consistent timestamps in UTC.
+- Keep writes lean; avoid PII where possible.
+
+## Next Steps
+- Add creation of indexes on first run.
+- Add a simple History panel to navigate sessions.
+- Add delete/prune utilities for old audio while keeping metadata.

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ numpy>=1.24.0
 # Optional: Database support
 # sqlite3  # Built into Python
 # sqlalchemy>=2.0.0
+pymongo>=4.7.0
 
 # Optional: Advanced audio processing
 # webrtcvad>=2.0.10  # Voice activity detection


### PR DESCRIPTION
This PR integrates MongoDB for session history and persistence.\n\nChanges:\n- db_mongo/: Mongo client and CRUD helpers (sessions, recordings, transcripts, evaluations)\n- app.py: wire Start/End/Transcribe/Evaluate to Mongo and add a History sidebar\n- docs/datastructure.md: Mongo collections, indexes, and flows\n- requirements.txt: add pymongo\n\nConfig:\n- MONGODB_URI, MONGODB_DB in .env/.env.example\n\nNotes:\n- Audio files remain on disk; DB stores metadata and paths\n- Basic error handling if Mongo is unavailable\n\nFollow-ups:\n- Add proper indexes on startup\n- Add delete/prune utilities for old audio\n- Optional: GridFS for audio blobs if required