### PR TITLE
feat(prompts): data-driven prompts from Wikipedia population dataset

### DIFF
--- a/app.py
+++ b/app.py
@@ -619,13 +619,8 @@ def main():
                                     pass
                                 st.success("✅ Assessment completed!")
                                 st.rerun()
-                    
-                    # No evaluation yet
-                    else:
-                        if st.session_state.latest_transcript_text:
-                            st.info("Click 'Evaluate Response' to get AI feedback on your transcript")
-                        else:
-                            st.info("Complete a recording and transcription to enable evaluation")
+                            except Exception as e:
+                                st.error(f"❌ Assessment failed: {e}")
             else:
                 st.subheader("🤖 AI Feedback")
                 st.info("Enable 'AI Assessment' in the sidebar to get detailed feedback")

--- a/app.py
+++ b/app.py
@@ -598,7 +598,7 @@ def main():
                                     last_rec = recs[0] if recs else None
                                     if last_rec:
                                         # find transcript for last_rec (latest)
-                                        transcripts = list(db_mongo.client.db.transcripts.find({"recording_id": last_rec["_id"]}).sort("created_at", -1))  # noqa: E501
+                                        transcripts = list(mongo_client.db.transcripts.find({"recording_id": last_rec["_id"]}).sort("created_at", -1))  # noqa: E501
                                         last_tr = transcripts[0] if transcripts else None
                                         if last_tr:
                                             mongo_add_evaluation(

--- a/app.py
+++ b/app.py
@@ -255,7 +255,8 @@ def main():
                     try:
                         sid = mongo_create_session(level=cefr_level)
                         st.session_state.test_session_id = sid
-                    except Exception as _:
+                    except Exception:
+                        # Fallback to ephemeral session id if DB is unavailable
                         st.session_state.test_session_id = f"session_{cefr_level}_{len(st.session_state.session_history)+1}"
                     # Add new session to session_history (UI only)
                     st.session_state.session_history.append({

--- a/data/scraped/population.json
+++ b/data/scraped/population.json
@@ -1,0 +1,954 @@
+[
+  {
+    "country": "World",
+    "population": 8021407192
+  },
+  {
+    "country": "India",
+    "population": 1425423212
+  },
+  {
+    "country": "China",
+    "population": 1425179569
+  },
+  {
+    "country": "United States",
+    "population": 341534046
+  },
+  {
+    "country": "Indonesia",
+    "population": 278830529
+  },
+  {
+    "country": "Pakistan",
+    "population": 243700667
+  },
+  {
+    "country": "Nigeria",
+    "population": 223150896
+  },
+  {
+    "country": "Brazil",
+    "population": 210306415
+  },
+  {
+    "country": "Bangladesh",
+    "population": 169384897
+  },
+  {
+    "country": "Russia",
+    "population": 145579899
+  },
+  {
+    "country": "Mexico",
+    "population": 128613117
+  },
+  {
+    "country": "Ethiopia",
+    "population": 125384287
+  },
+  {
+    "country": "Japan",
+    "population": 124997578
+  },
+  {
+    "country": "Philippines",
+    "population": 113964338
+  },
+  {
+    "country": "Egypt",
+    "population": 112618250
+  },
+  {
+    "country": "DR Congo",
+    "population": 102396968
+  },
+  {
+    "country": "Vietnam",
+    "population": 99680655
+  },
+  {
+    "country": "Iran",
+    "population": 89524246
+  },
+  {
+    "country": "Turkey",
+    "population": 87058473
+  },
+  {
+    "country": "Germany",
+    "population": 84086227
+  },
+  {
+    "country": "Thailand",
+    "population": 71735329
+  },
+  {
+    "country": "United Kingdom",
+    "population": 68179315
+  },
+  {
+    "country": "Tanzania",
+    "population": 64711821
+  },
+  {
+    "country": "France",
+    "population": 66277409
+  },
+  {
+    "country": "South Africa",
+    "population": 62378410
+  },
+  {
+    "country": "Italy",
+    "population": 59619115
+  },
+  {
+    "country": "Kenya",
+    "population": 54252461
+  },
+  {
+    "country": "Myanmar",
+    "population": 53756787
+  },
+  {
+    "country": "Colombia",
+    "population": 51737944
+  },
+  {
+    "country": "South Korea",
+    "population": 51782512
+  },
+  {
+    "country": "Sudan",
+    "population": 49383346
+  },
+  {
+    "country": "Uganda",
+    "population": 47312719
+  },
+  {
+    "country": "Spain",
+    "population": 47828382
+  },
+  {
+    "country": "Algeria",
+    "population": 45477389
+  },
+  {
+    "country": "Argentina",
+    "population": 45407904
+  },
+  {
+    "country": "Iraq",
+    "population": 44070551
+  },
+  {
+    "country": "Afghanistan",
+    "population": 40578842
+  },
+  {
+    "country": "Yemen",
+    "population": 38222876
+  },
+  {
+    "country": "Canada",
+    "population": 38821259
+  },
+  {
+    "country": "Poland",
+    "population": 38385739
+  },
+  {
+    "country": "Ukraine",
+    "population": 41048766
+  },
+  {
+    "country": "Morocco",
+    "population": 37329064
+  },
+  {
+    "country": "Angola",
+    "population": 35635029
+  },
+  {
+    "country": "Uzbekistan",
+    "population": 34938955
+  },
+  {
+    "country": "Malaysia",
+    "population": 34695493
+  },
+  {
+    "country": "Peru",
+    "population": 33475438
+  },
+  {
+    "country": "Ghana",
+    "population": 33149152
+  },
+  {
+    "country": "Mozambique",
+    "population": 32656246
+  },
+  {
+    "country": "Saudi Arabia",
+    "population": 32175352
+  },
+  {
+    "country": "Madagascar",
+    "population": 30437261
+  },
+  {
+    "country": "Ivory Coast",
+    "population": 30395002
+  },
+  {
+    "country": "Nepal",
+    "population": 29715436
+  },
+  {
+    "country": "Cameroon",
+    "population": 27632771
+  },
+  {
+    "country": "Venezuela",
+    "population": 28213017
+  },
+  {
+    "country": "Australia",
+    "population": 26200984
+  },
+  {
+    "country": "North Korea",
+    "population": 26329845
+  },
+  {
+    "country": "Niger",
+    "population": 25311973
+  },
+  {
+    "country": "Mali",
+    "population": 23072640
+  },
+  {
+    "country": "Syria",
+    "population": 22462173
+  },
+  {
+    "country": "Taiwan",
+    "population": 23420111
+  },
+  {
+    "country": "Burkina Faso",
+    "population": 22509038
+  },
+  {
+    "country": "Sri Lanka",
+    "population": 22834965
+  },
+  {
+    "country": "Malawi",
+    "population": 20568728
+  },
+  {
+    "country": "Zambia",
+    "population": 20152938
+  },
+  {
+    "country": "Kazakhstan",
+    "population": 20034609
+  },
+  {
+    "country": "Chile",
+    "population": 19553036
+  },
+  {
+    "country": "Chad",
+    "population": 18455316
+  },
+  {
+    "country": "Romania",
+    "population": 19166772
+  },
+  {
+    "country": "Somalia",
+    "population": 17801897
+  },
+  {
+    "country": "Guatemala",
+    "population": 17847877
+  },
+  {
+    "country": "Senegal",
+    "population": 17651103
+  },
+  {
+    "country": "Netherlands",
+    "population": 17904421
+  },
+  {
+    "country": "Ecuador",
+    "population": 17823897
+  },
+  {
+    "country": "Cambodia",
+    "population": 17201724
+  },
+  {
+    "country": "Zimbabwe",
+    "population": 16069056
+  },
+  {
+    "country": "Guinea",
+    "population": 14055137
+  },
+  {
+    "country": "Benin",
+    "population": 13759501
+  },
+  {
+    "country": "Rwanda",
+    "population": 13651030
+  },
+  {
+    "country": "Burundi",
+    "population": 13321097
+  },
+  {
+    "country": "Bolivia",
+    "population": 12077154
+  },
+  {
+    "country": "Tunisia",
+    "population": 12119334
+  },
+  {
+    "country": "Belgium",
+    "population": 11641820
+  },
+  {
+    "country": "Haiti",
+    "population": 11503606
+  },
+  {
+    "country": "South Sudan",
+    "population": 11021177
+  },
+  {
+    "country": "Jordan",
+    "population": 11256263
+  },
+  {
+    "country": "Dominican Republic",
+    "population": 11230734
+  },
+  {
+    "country": "Cuba",
+    "population": 11059820
+  },
+  {
+    "country": "Czechia",
+    "population": 10673213
+  },
+  {
+    "country": "Honduras",
+    "population": 10463872
+  },
+  {
+    "country": "United Arab Emirates",
+    "population": 10242086
+  },
+  {
+    "country": "Sweden",
+    "population": 10487338
+  },
+  {
+    "country": "Portugal",
+    "population": 10417073
+  },
+  {
+    "country": "Tajikistan",
+    "population": 10182222
+  },
+  {
+    "country": "Papua New Guinea",
+    "population": 10203169
+  },
+  {
+    "country": "Azerbaijan",
+    "population": 10295304
+  },
+  {
+    "country": "Greece",
+    "population": 10412480
+  },
+  {
+    "country": "Hungary",
+    "population": 9964306
+  },
+  {
+    "country": "Togo",
+    "population": 9089738
+  },
+  {
+    "country": "Israel",
+    "population": 9103151
+  },
+  {
+    "country": "Austria",
+    "population": 9064677
+  },
+  {
+    "country": "Belarus",
+    "population": 9173237
+  },
+  {
+    "country": "Switzerland",
+    "population": 8792182
+  },
+  {
+    "country": "Sierra Leone",
+    "population": 8276807
+  },
+  {
+    "country": "Laos",
+    "population": 7559007
+  },
+  {
+    "country": "Hong Kong(China)",
+    "population": 7465915
+  },
+  {
+    "country": "Turkmenistan",
+    "population": 7230193
+  },
+  {
+    "country": "Libya",
+    "population": 7223805
+  },
+  {
+    "country": "Kyrgyzstan",
+    "population": 6955788
+  },
+  {
+    "country": "Paraguay",
+    "population": 6760464
+  },
+  {
+    "country": "Nicaragua",
+    "population": 6730654
+  },
+  {
+    "country": "Bulgaria",
+    "population": 6825864
+  },
+  {
+    "country": "Serbia",
+    "population": 6791213
+  },
+  {
+    "country": "El Salvador",
+    "population": 6280319
+  },
+  {
+    "country": "Congo",
+    "population": 6035104
+  },
+  {
+    "country": "Denmark",
+    "population": 5902904
+  },
+  {
+    "country": "Singapore",
+    "population": 5649885
+  },
+  {
+    "country": "Lebanon",
+    "population": 5744489
+  },
+  {
+    "country": "Finland",
+    "population": 5569299
+  },
+  {
+    "country": "Norway",
+    "population": 5457801
+  },
+  {
+    "country": "Slovakia",
+    "population": 5473197
+  },
+  {
+    "country": "Liberia",
+    "population": 5373294
+  },
+  {
+    "country": "Palestine",
+    "population": 5305270
+  },
+  {
+    "country": "Ireland",
+    "population": 5110016
+  },
+  {
+    "country": "New Zealand",
+    "population": 5131734
+  },
+  {
+    "country": "Central African Republic",
+    "population": 5098039
+  },
+  {
+    "country": "Costa Rica",
+    "population": 5081765
+  },
+  {
+    "country": "Oman",
+    "population": 4730226
+  },
+  {
+    "country": "Mauritania",
+    "population": 4875637
+  },
+  {
+    "country": "Kuwait",
+    "population": 4589511
+  },
+  {
+    "country": "Panama",
+    "population": 4400773
+  },
+  {
+    "country": "Croatia",
+    "population": 3907027
+  },
+  {
+    "country": "Georgia",
+    "population": 3794784
+  },
+  {
+    "country": "Eritrea",
+    "population": 3409447
+  },
+  {
+    "country": "Mongolia",
+    "population": 3386015
+  },
+  {
+    "country": "Uruguay",
+    "population": 3390913
+  },
+  {
+    "country": "Puerto Rico(United States)",
+    "population": 3240968
+  },
+  {
+    "country": "Bosnia and Herzegovina",
+    "population": 3204802
+  },
+  {
+    "country": "Moldova",
+    "population": 3039985
+  },
+  {
+    "country": "Qatar",
+    "population": 2892455
+  },
+  {
+    "country": "Namibia",
+    "population": 2889662
+  },
+  {
+    "country": "Armenia",
+    "population": 2880874
+  },
+  {
+    "country": "Lithuania",
+    "population": 2816919
+  },
+  {
+    "country": "Jamaica",
+    "population": 2839144
+  },
+  {
+    "country": "Albania",
+    "population": 2827608
+  },
+  {
+    "country": "Gambia",
+    "population": 2636470
+  },
+  {
+    "country": "Gabon",
+    "population": 2430747
+  },
+  {
+    "country": "Botswana",
+    "population": 2439892
+  },
+  {
+    "country": "Lesotho",
+    "population": 2286110
+  },
+  {
+    "country": "Guinea-Bissau",
+    "population": 2105529
+  },
+  {
+    "country": "Slovenia",
+    "population": 2115228
+  },
+  {
+    "country": "Latvia",
+    "population": 1881063
+  },
+  {
+    "country": "Equatorial Guinea",
+    "population": 1803545
+  },
+  {
+    "country": "North Macedonia",
+    "population": 1840233
+  },
+  {
+    "country": "Kosovo",
+    "population": 1717946
+  },
+  {
+    "country": "Bahrain",
+    "population": 1533459
+  },
+  {
+    "country": "Trinidad and Tobago",
+    "population": 1495921
+  },
+  {
+    "country": "Timor-Leste",
+    "population": 1369295
+  },
+  {
+    "country": "Estonia",
+    "population": 1350091
+  },
+  {
+    "country": "Cyprus",
+    "population": 1331370
+  },
+  {
+    "country": "Mauritius",
+    "population": 1276130
+  },
+  {
+    "country": "Eswatini",
+    "population": 1218917
+  },
+  {
+    "country": "Djibouti",
+    "population": 1137096
+  },
+  {
+    "country": "Fiji",
+    "population": 919422
+  },
+  {
+    "country": "Réunion(France)",
+    "population": 871540
+  },
+  {
+    "country": "Comoros",
+    "population": 834188
+  },
+  {
+    "country": "Guyana",
+    "population": 821637
+  },
+  {
+    "country": "Solomon Islands",
+    "population": 781066
+  },
+  {
+    "country": "Bhutan",
+    "population": 780914
+  },
+  {
+    "country": "Macao(China)",
+    "population": 704356
+  },
+  {
+    "country": "Luxembourg",
+    "population": 653313
+  },
+  {
+    "country": "Montenegro",
+    "population": 614648
+  },
+  {
+    "country": "Suriname",
+    "population": 623164
+  },
+  {
+    "country": "Western Sahara(disputed)",
+    "population": 568739
+  },
+  {
+    "country": "Malta",
+    "population": 528192
+  },
+  {
+    "country": "Maldives",
+    "population": 524106
+  },
+  {
+    "country": "Cape Verde",
+    "population": 519741
+  },
+  {
+    "country": "Brunei",
+    "population": 455370
+  },
+  {
+    "country": "Belize",
+    "population": 402733
+  },
+  {
+    "country": "Bahamas",
+    "population": 397538
+  },
+  {
+    "country": "Iceland",
+    "population": 380356
+  },
+  {
+    "country": "Guadeloupe(France)",
+    "population": 384697
+  },
+  {
+    "country": "Martinique(France)",
+    "population": 349459
+  },
+  {
+    "country": "Vanuatu",
+    "population": 313046
+  },
+  {
+    "country": "Mayotte(France)",
+    "population": 305269
+  },
+  {
+    "country": "French Guiana(France)",
+    "population": 298306
+  },
+  {
+    "country": "New Caledonia(France)",
+    "population": 287123
+  },
+  {
+    "country": "Barbados",
+    "population": 288318
+  },
+  {
+    "country": "French Polynesia(France)",
+    "population": 280378
+  },
+  {
+    "country": "São Tomé and Príncipe",
+    "population": 226305
+  },
+  {
+    "country": "Samoa",
+    "population": 215261
+  },
+  {
+    "country": "Curaçao(Netherlands)",
+    "population": 185345
+  },
+  {
+    "country": "Saint Lucia",
+    "population": 178781
+  },
+  {
+    "country": "Guam(United States)",
+    "population": 165180
+  },
+  {
+    "country": "Kiribati",
+    "population": 130469
+  },
+  {
+    "country": "Seychelles",
+    "population": 125522
+  },
+  {
+    "country": "Grenada",
+    "population": 116913
+  },
+  {
+    "country": "Micronesia",
+    "population": 112114
+  },
+  {
+    "country": "Tonga",
+    "population": 105042
+  },
+  {
+    "country": "Aruba(Netherlands)",
+    "population": 107782
+  },
+  {
+    "country": "Jersey(United Kingdom)",
+    "population": 103490
+  },
+  {
+    "country": "Saint Vincent and the Grenadines",
+    "population": 102046
+  },
+  {
+    "country": "Antigua and Barbuda",
+    "population": 92840
+  },
+  {
+    "country": "U.S. Virgin Islands(United States)",
+    "population": 86507
+  },
+  {
+    "country": "Isle of Man(United Kingdom)",
+    "population": 84132
+  },
+  {
+    "country": "Andorra",
+    "population": 79705
+  },
+  {
+    "country": "Cayman Islands(United Kingdom)",
+    "population": 71591
+  },
+  {
+    "country": "Dominica",
+    "population": 66826
+  },
+  {
+    "country": "Bermuda(United Kingdom)",
+    "population": 64749
+  },
+  {
+    "country": "Guernsey(United Kingdom)",
+    "population": 63725
+  },
+  {
+    "country": "Greenland(Denmark)",
+    "population": 54990
+  },
+  {
+    "country": "Faroe Islands(Denmark)",
+    "population": 54011
+  },
+  {
+    "country": "American Samoa(United States)",
+    "population": 48342
+  },
+  {
+    "country": "Saint Kitts and Nevis",
+    "population": 46709
+  },
+  {
+    "country": "Turks and Caicos Islands(United Kingdom)",
+    "population": 45847
+  },
+  {
+    "country": "Northern Mariana Islands(United States)",
+    "population": 46078
+  },
+  {
+    "country": "Sint Maarten(Netherlands)",
+    "population": 42139
+  },
+  {
+    "country": "Liechtenstein",
+    "population": 39317
+  },
+  {
+    "country": "British Virgin Islands(United Kingdom)",
+    "population": 38319
+  },
+  {
+    "country": "Monaco",
+    "population": 38931
+  },
+  {
+    "country": "Gibraltar(United Kingdom)",
+    "population": 37609
+  },
+  {
+    "country": "Marshall Islands",
+    "population": 40077
+  },
+  {
+    "country": "San Marino",
+    "population": 34090
+  },
+  {
+    "country": "Caribbean Netherlands(Netherlands)",
+    "population": 28627
+  },
+  {
+    "country": "Saint Martin(France)",
+    "population": 28870
+  },
+  {
+    "country": "Palau",
+    "population": 17759
+  },
+  {
+    "country": "Anguilla(United Kingdom)",
+    "population": 14180
+  },
+  {
+    "country": "Cook Islands(New Zealand)",
+    "population": 14723
+  },
+  {
+    "country": "Nauru",
+    "population": 11801
+  },
+  {
+    "country": "Wallis and Futuna(France)",
+    "population": 11478
+  },
+  {
+    "country": "Saint Barthélemy(France)",
+    "population": 10920
+  },
+  {
+    "country": "Tuvalu",
+    "population": 9992
+  },
+  {
+    "country": "Saint Pierre and Miquelon(France)",
+    "population": 5732
+  },
+  {
+    "country": "Saint Helena(United Kingdom)",
+    "population": 5343
+  },
+  {
+    "country": "Montserrat(United Kingdom)",
+    "population": 4453
+  },
+  {
+    "country": "Falkland Islands(United Kingdom)",
+    "population": 3490
+  },
+  {
+    "country": "Tokelau(New Zealand)",
+    "population": 2290
+  },
+  {
+    "country": "Niue(New Zealand)",
+    "population": 1821
+  },
+  {
+    "country": "Vatican City",
+    "population": 505
+  }
+]

--- a/db_mongo/client.py
+++ b/db_mongo/client.py
@@ -5,5 +5,13 @@ from dotenv import load_dotenv
 load_dotenv()
 MONGODB_URI = os.getenv("MONGODB_URI", "mongodb://localhost:27017")
 MONGODB_DB = os.getenv("MONGODB_DB", "speak_check")
-client = MongoClient(MONGODB_URI)
-db = client[MONGODB_DB]
+
+# Use short timeouts to avoid UI freezing if Mongo is unavailable
+_client = MongoClient(
+    MONGODB_URI,
+    serverSelectionTimeoutMS=1000,
+    connectTimeoutMS=1000,
+    socketTimeoutMS=1000,
+)
+
+db = _client[MONGODB_DB]

--- a/scripts/scrape_population.py
+++ b/scripts/scrape_population.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+import argparse, json, pathlib, re, time
+from typing import List, Dict
+import pandas as pd
+import requests
+from bs4 import BeautifulSoup
+
+URL = "https://en.wikipedia.org/wiki/List_of_countries_by_population_(United_Nations)"
+UA = {"User-Agent": "speak-check/1.0 (education)"}
+
+FOOTNOTE_RE = re.compile(r"\[.*?\]")
+
+
+def fetch_html(url: str) -> str:
+    r = requests.get(url, headers=UA, timeout=20)
+    r.raise_for_status()
+    return r.text
+
+
+def clean_country(name: str) -> str:
+    name = FOOTNOTE_RE.sub("", str(name)).strip()
+    name = name.replace("\xa0", " ")
+    return name
+
+
+def to_int(val) -> int:
+    try:
+        s = str(val).replace(",", "").strip()
+        return int(float(s))
+    except Exception:
+        return None
+
+
+def parse_population(html: str) -> List[Dict]:
+    # First try pandas tables
+    tables = pd.read_html(html)
+    cand = None
+    for t in tables:
+        cols = {c.lower().strip() for c in t.columns}
+        if ("country/area" in cols or "country or area" in cols or "country" in cols) and any(
+            k in cols for k in ["population","population(1 july)","population(1 july 2023)"]
+        ):
+            cand = t
+            break
+    if cand is None:
+        # Fallback: bs4
+        soup = BeautifulSoup(html, "html.parser")
+        table = soup.select_one("table.wikitable")
+        rows = []
+        if not table:
+            return rows
+        headers = [th.get_text(strip=True) for th in table.select("tr th")]
+        for tr in table.select("tr")[1:]:
+            tds = [td.get_text(strip=True) for td in tr.select("td")]
+            if len(tds) >= 2:
+                rows.append({"country": clean_country(tds[0]), "population": to_int(tds[1])})
+        return rows
+
+    df = cand.rename(columns=lambda c: str(c).strip())
+    # Heuristic column names
+    ctry_col = next((c for c in df.columns if c.lower().startswith("country")), None)
+    pop_col = next((c for c in df.columns if "population" in c.lower()), None)
+    year = None
+    m = re.search(r"(\d{4})", pop_col or "")
+    if m:
+        year = int(m.group(1))
+    df = df[[ctry_col, pop_col]].copy()
+    df[ctry_col] = df[ctry_col].map(clean_country)
+    df[pop_col] = df[pop_col].map(to_int)
+    df = df.dropna()
+    ts = int(time.time())
+    out = []
+    for _, r in df.iterrows():
+        out.append({
+            "country": r[ctry_col],
+            "population": int(r[pop_col]),
+            "year": year,
+            "source_url": URL,
+            "scraped_at": ts,
+        })
+    return out
+
+
+def main(out: str):
+    html = fetch_html(URL)
+    recs = parse_population(html)
+    p = pathlib.Path(out)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    if p.suffix.lower() == ".csv":
+        pd.DataFrame(recs).to_csv(p, index=False)
+    else:
+        p.write_text(json.dumps(recs, ensure_ascii=False, indent=2))
+    print(f"Saved {len(recs)} records to {p}")
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default="data/scraped/population.json")
+    args = ap.parse_args()
+    main(args.out)


### PR DESCRIPTION
Adds a population scraper and integrates data-driven prompts.\n\nWhat’s included:\n- scripts/scrape_population.py: scrapes UN/Wikipedia population table; outputs JSON/CSV\n- data/scraped/population.json: 238 normalized records (country, population, year if present)\n- app.py: sidebar toggle 'Use population dataset'; prompt factory for A2–C1; New Question and prompt display wired\n\nHow to use:\n1) Optional refresh: ./scripts/scrape_population.py --out data/scraped/population.json\n2) In the app sidebar, enable 'Use population dataset' and click 'New Question'\n\nNotes:\n- Source: Wikipedia (CC BY-SA 3.0) — link embedded in the script\n- No external API cost; cached in-app\n\nFollow-ups:\n- Region filter in sidebar\n- More templates (time trends) and rubric hooks for evaluation\n- Monthly GitHub Action to refresh dataset