### PR TITLE
K8s local deploy + browser mic recorder + Docker hardening + CI security scan

### DIFF
--- a/docs/k8s.md
+++ b/docs/k8s.md
@@ -1,0 +1,56 @@
+# Local Kubernetes (k3d) Deployment
+
+This guide runs the CEFR Speaking Exam Simulator on a local Kubernetes cluster using k3d (no Docker Desktop), Colima for Docker runtime, and kubectl.
+
+## Prerequisites
+- Colima running (Docker CLI available)
+- kubectl
+- k3d
+
+## Build the image
+```bash
+docker build -t speak-check:latest .
+```
+
+## Create cluster and map ports
+```bash
+k3d cluster create speak-check \
+  -p "8501:30080@loadbalancer" \
+  -p "27018:30017@loadbalancer"
+```
+
+## Load image into the cluster
+```bash
+k3d image import speak-check:latest -c speak-check
+```
+
+## Apply manifests
+```bash
+kubectl apply -f k8s/namespace.yaml
+kubectl -n speak-check apply -f k8s/configmap.yaml -f k8s/secret.yaml
+kubectl -n speak-check apply -f k8s/mongo-statefulset.yaml -f k8s/mongo-service.yaml \
+  -f k8s/app-deployment.yaml -f k8s/app-service.yaml
+```
+
+## Create secrets (do not commit keys)
+```bash
+kubectl -n speak-check create secret generic app-secrets \
+  --from-literal=OPENAI_API_KEY="$OPENAI_API_KEY" \
+  --from-literal=GITHUB_PERSONAL_ACCESS_TOKEN="$GITHUB_PERSONAL_ACCESS_TOKEN"
+```
+
+## Verify
+```bash
+kubectl -n speak-check rollout status deploy/speak-check-app
+kubectl -n speak-check get pods,svc
+curl -f http://localhost:8501/_stcore/health
+```
+
+## Access
+- App: http://localhost:8501
+- MongoDB (local tools): localhost:27018 -> cluster 27017
+
+## Cleanup
+```bash
+k3d cluster delete speak-check
+```

--- a/k8s/app-deployment.yaml
+++ b/k8s/app-deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: speak-check-app
+  namespace: speak-check
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: speak-check-app
+  template:
+    metadata:
+      labels:
+        app: speak-check-app
+    spec:
+      containers:
+        - name: app
+          image: speak-check:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8501
+          env:
+            - name: MONGODB_DB
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: MONGODB_DB
+            - name: MONGODB_URI
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: MONGODB_URI_INTERNAL
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: OPENAI_API_KEY
+            - name: GITHUB_PERSONAL_ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: GITHUB_PERSONAL_ACCESS_TOKEN
+          readinessProbe:
+            httpGet:
+              path: /_stcore/health
+              port: 8501
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /_stcore/health
+              port: 8501
+            initialDelaySeconds: 30
+            periodSeconds: 30

--- a/k8s/app-service.yaml
+++ b/k8s/app-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: speak-check-app
+  namespace: speak-check
+spec:
+  selector:
+    app: speak-check-app
+  ports:
+    - name: http
+      port: 8501
+      targetPort: 8501
+      nodePort: 30080
+  type: NodePort

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+  namespace: speak-check
+data:
+  MONGODB_DB: "speak_check"
+  MONGODB_URI_INTERNAL: "mongodb://mongo:27017"

--- a/k8s/mongo-service.yaml
+++ b/k8s/mongo-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongo
+  namespace: speak-check
+spec:
+  selector:
+    app: mongo
+  ports:
+    - name: mongo
+      port: 27017
+      targetPort: 27017
+  type: ClusterIP

--- a/k8s/mongo-statefulset.yaml
+++ b/k8s/mongo-statefulset.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mongo
+  namespace: speak-check
+spec:
+  serviceName: mongo
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mongo
+  template:
+    metadata:
+      labels:
+        app: mongo
+    spec:
+      containers:
+        - name: mongo
+          image: mongo:7.0
+          ports:
+            - containerPort: 27017
+          volumeMounts:
+            - name: mongo-data
+              mountPath: /data/db
+          readinessProbe:
+            exec:
+              command: ["mongosh", "--eval", "db.adminCommand('ping')"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command: ["mongosh", "--eval", "db.adminCommand('ping')"]
+            initialDelaySeconds: 30
+            periodSeconds: 30
+  volumeClaimTemplates:
+    - metadata:
+        name: mongo-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: speak-check

--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-secrets
+  namespace: speak-check
+type: Opaque
+# NOTE: Do not commit real data. Create at deploy time, e.g.:
+# kubectl -n speak-check create secret generic app-secrets \
+#   --from-literal=OPENAI_API_KEY="$OPENAI_API_KEY" \
+#   --from-literal=GITHUB_PERSONAL_ACCESS_TOKEN="$GITHUB_PERSONAL_ACCESS_TOKEN"


### PR DESCRIPTION
- Add browser mic recorder fallback (audio_recorder_streamlit) and in-browser playback (st.audio)\n- Upload audio fallback and robust file detection for playback\n- Persistent port-forward helper (scripts/portforward.sh)\n- Dockerfile hardening, base pinned, healthcheck; CI Trivy scan + Dependabot\n- Fix STT/Eval type issues; resilient STT request\n- Rebuild and verified on k3d; app accessible via port-forward\n\nNo secrets committed.